### PR TITLE
automatic npmjs deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,15 @@ before_deploy:
   - rustup target add wasm32-unknown-unknown
   - cargo install wasm-pack
   - ~/.cargo/bin/wasm-pack build --release -t nodejs --scope hfour
+
+# use dpl2 for the src: option
+deploy:
+  edge: true
+  provider: npm
+  email: gdamjan@hfour.com
+  api_key:
+    secure: "uk+PIgO0ixURcqlOQ561xADcgBhg5iYYx1B7eXs3n4+vLPrxMMmMmkfwo3UbU9lYzEJcPBKL/P7w9CApJDeog7CH5TtF3JHt1xjq4BjeyvVNHqsHy/x6LHFgFhN3IR5IZwxuVHL853yh2z/zbSsE4cLu26Hx2AESYRn9GZWT4SX7XF0iKLQhORNSir5xC49r2El+hgrCzSE7Y5UaGpA0UITTQrpaoZF8ZltYHINk4yB9tWozDdEFabRnONQ31aWvBijocopyN8ifazccd/YqM0bsyCFWHHht9r7LH7sCiarJL05z0mnfDv79K2UEYC68xCMDY3V/1Mp1WkFosGwKwlrsFP5RlGkmifXyWvNDQDaFyUTuk+ZQSKbUX1BEbbfTpVKpwN+hZBJFuVX1Q10ojitiE57ahx+BhRyEo63pYQ5TG9fPvT8YIMXGvLicbOeu9+2EqZzizF6yg8nV3EIPmR7xoghGHbwERv3tcjj0Nii4U6Lq23XkORZPIyIZ52HCBaDq75fgb9i+jEPnkGhtQfW57f3D4TqLkhvpa2KV/YdvfuC9D6g6lPH3h9h2W7PHfWPBG8Sh02rLCYEumqCASUgrPFte7irVZ4OOePDP158zXzMylusteyAlJaR/zIl/LdLw+DISkc042ZDDwC5igdaRpVxNpQfUB3w1A0Q42CI="
+  on:
+    tags: true
+    branch: master
+  src: ./pkg

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ fs.writeFileSync('solution.jpg', img2);
 * https://rustwasm.github.io/docs/wasm-bindgen/
 * https://www.joyent.com/blog/improved-wasm-support-coming-to-node
 * https://dev.to/dandyvica/wasm-in-rust-without-nodejs-2e0c
+
+# Making a release on npmjs
+
+This repo has travis configured to publish the build node package on npmjs. When a commit on the master branch is
+tagged, travis will try to push the package to npmjs. The version of the node package is copied from `Cargo.toml`, so
+it's up to you make sure the version is updated accordingly. The tag name is not used, but should follow the version in
+`Cargo.toml` (and so the node package version). For example, the 0.1.0 version should be tagged as `v0.1.0`.


### PR DESCRIPTION
travis will automatically deploy the built package on npmjs when a commit in the master branch is tagged. the npm package version is taken from the version in `Cargo.toml`.

the `edge: true` option enables the use of dpl v2, since the newer npm
provider has the `src:` option.

https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release